### PR TITLE
Encapsulate AudioItem dirty-tracking behind intent-named mutators

### DIFF
--- a/src/MediaPlayer.Model/Builders/AudioItemBuilder.cs
+++ b/src/MediaPlayer.Model/Builders/AudioItemBuilder.cs
@@ -52,16 +52,9 @@ namespace MediaPlayer.Model.ObjectBuilders
             return this;
         }
 
-        /// <summary>
-        /// On initial read, setting "IsDirty" to false so we don't write same data back to it later
-        /// </summary>
-        /// <param name="lyrics"></param>
-        /// <returns></returns>
         public AudioItemBuilder WithLyrics(string lyrics)
         {
-            _audioItem.Lyrics = lyrics;
-
-            _audioItem.DirtyProperties.Remove(nameof(_audioItem.Lyrics));
+            _audioItem.SetLyrics(lyrics);
 
             return this;
         }
@@ -73,15 +66,9 @@ namespace MediaPlayer.Model.ObjectBuilders
             return this;
         }
 
-        /// <summary>
-        /// On initial read, setting "IsDirty" to false so we don't write same data back to it later
-        /// </summary>
-        /// <param name="albumArt"></param>
-        /// <returns></returns>
         public AudioItemBuilder WithAlbumArt(byte[] albumArt)
         {
-            _audioItem.AlbumArt = albumArt;
-            _audioItem.DirtyProperties.Remove(nameof(_audioItem.AlbumArt));
+            _audioItem.DisplayLocalAlbumArt(albumArt);
 
             return this;
         }

--- a/src/MediaPlayer.Model/Business Entities/Concrete/AudioItem.cs
+++ b/src/MediaPlayer.Model/Business Entities/Concrete/AudioItem.cs
@@ -1,7 +1,6 @@
 ﻿using Generic.Extensions;
 using MediaPlayer.Model.BusinessEntities.Abstract;
 using System.Diagnostics;
-using System.Linq;
 
 namespace MediaPlayer.Model.BusinessEntities.Concrete
 {
@@ -20,17 +19,20 @@ namespace MediaPlayer.Model.BusinessEntities.Concrete
         public bool HasLyrics => !string.IsNullOrEmpty(_lyrics);
         public bool HasAlbumArt => !_albumArt.IsNullOrEmpty();
 
-        public byte[] AlbumArt
-        {
-            get => _albumArt;
-            set
-            {
-                _albumArt = value;
-                DirtyProperties.Add(nameof(AlbumArt));
+        public byte[] AlbumArt => _albumArt;
 
-                OnPropertyChanged(nameof(AlbumArt));
-                OnPropertyChanged(nameof(HasAlbumArt));
-            }
+        public void DisplayLocalAlbumArt(byte[] albumArt)
+        {
+            _albumArt = albumArt;
+
+            OnPropertyChanged(nameof(AlbumArt));
+            OnPropertyChanged(nameof(HasAlbumArt));
+        }
+
+        public void EnrichAlbumArt(byte[] albumArt)
+        {
+            DisplayLocalAlbumArt(albumArt);
+            DirtyProperties.Add(nameof(AlbumArt));
         }
 
         public string Album
@@ -80,17 +82,20 @@ namespace MediaPlayer.Model.BusinessEntities.Concrete
                 OnPropertyChanged(nameof(Year));
             } 
         }
-        public string Lyrics
-        {
-            get => _lyrics;
-            set
-            {
-                _lyrics = value;
-                DirtyProperties.Add(nameof(Lyrics));
+        public string Lyrics => _lyrics;
 
-                OnPropertyChanged(nameof(Lyrics));
-                OnPropertyChanged(nameof(HasLyrics));
-            } 
+        public void SetLyrics(string lyrics)
+        {
+            _lyrics = lyrics;
+
+            OnPropertyChanged(nameof(Lyrics));
+            OnPropertyChanged(nameof(HasLyrics));
+        }
+
+        public void EnrichLyrics(string lyrics)
+        {
+            SetLyrics(lyrics);
+            DirtyProperties.Add(nameof(Lyrics));
         }
 
 

--- a/src/MediaPlayer.Model/Metadata/Concrete/Correctors/AlbumArtCorrector.cs
+++ b/src/MediaPlayer.Model/Metadata/Concrete/Correctors/AlbumArtCorrector.cs
@@ -24,8 +24,9 @@ namespace MediaPlayer.Model.Metadata.Concrete.Correctors
         {
             var audioItem = mediaItem as AudioItem;
 
-            audioItem.AlbumArt = SearchForAlbumArtInDirectory(audioItem.FilePath.LocalPath);
-            audioItem.DirtyProperties.Remove(nameof(audioItem.AlbumArt));
+            var albumArt = SearchForAlbumArtInDirectory(audioItem.FilePath.LocalPath);
+
+            audioItem.DisplayLocalAlbumArt(albumArt);
         }
 
         private byte[] SearchForAlbumArtInDirectory(string path)

--- a/src/MediaPlayer.Model/Metadata/Concrete/Correctors/LyricsCorrector.cs
+++ b/src/MediaPlayer.Model/Metadata/Concrete/Correctors/LyricsCorrector.cs
@@ -21,8 +21,9 @@ namespace MediaPlayer.Model.Metadata.Concrete.Correctors
         {
             var audioItem = mediaItem as AudioItem;
 
-            audioItem.Lyrics = audioItem.Lyrics.ReplaceTwoSucceedingNewLinesWithOne();
-            audioItem.DirtyProperties.Remove(nameof(audioItem.Lyrics));
+            var lyrics = audioItem.Lyrics.ReplaceTwoSucceedingNewLinesWithOne();
+
+            audioItem.SetLyrics(lyrics);
         }
     }
 }

--- a/src/MediaPlayer.Model/Metadata/Concrete/Updaters/LastFmAlbumArtMetadataUpdater.cs
+++ b/src/MediaPlayer.Model/Metadata/Concrete/Updaters/LastFmAlbumArtMetadataUpdater.cs
@@ -27,9 +27,10 @@ namespace MediaPlayer.Model.Metadata.Concrete.Updaters
             })
             .Build();
 
+        private static bool IsTransient(FlurlHttpException ex) => ex.StatusCode is null || ex.StatusCode >= 500 || ex.StatusCode == 408;
+
         readonly ILastFMApi _lastFmApi;
         readonly IRuntimeCache<byte[]> _cache;
-
 
         [ImportingConstructor]
         public LastFmAlbumArtMetadataUpdater(ILastFMApi lastFmApi, IRuntimeCache<byte[]> cache)
@@ -65,7 +66,5 @@ namespace MediaPlayer.Model.Metadata.Concrete.Updaters
             }
         }
 
-        private static bool IsTransient(FlurlHttpException ex)
-            => ex.StatusCode is null || ex.StatusCode >= 500 || ex.StatusCode == 408;
     }
 }

--- a/src/MediaPlayer.ViewModel.Test/ServicesTests/MetadataWriterServiceTests.cs
+++ b/src/MediaPlayer.ViewModel.Test/ServicesTests/MetadataWriterServiceTests.cs
@@ -31,7 +31,7 @@ namespace MediaPlayer.ViewModel.Test.ServicesTests
                     if (audioItem == null || !audioItem.DirtyProperties.Contains(nameof(audioItem.Lyrics)))
                         return;
 
-                    audioItem.Lyrics = "I am adding some lyrics";
+                    audioItem.EnrichLyrics("I am adding some lyrics");
                     audioItem.DirtyProperties.Remove(nameof(audioItem.Lyrics));
                 });
 

--- a/src/MediaPlayer.ViewModel.Test/TestData.cs
+++ b/src/MediaPlayer.ViewModel.Test/TestData.cs
@@ -8,13 +8,17 @@ namespace MediaPlayer.ViewModel.Test
     {
         public static string InputTestFilesPath = $"_Test Files/Input Files";
 
+        static TestData()
+        {
+            AudioItem1.SetLyrics("Test \n\n Lyrics \n\n Spacing");
+        }
+
         public static AudioItem AudioItem1 = new()
         {
             Id = 1,
             Album = "Found in Far Away Places",
             Artist = "August Burns Red",
             MediaTitle = "Majoring in the Minors",
-            Lyrics = "Test \n\n Lyrics \n\n Spacing",
             FilePath = new Uri($"{Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)}/_Test Files/Input Files/06. Majoring in the Minors.mp3")
         };
 

--- a/src/MediaPlayer.ViewModel.Test/ViewModelTests/MainViewModelTests.cs
+++ b/src/MediaPlayer.ViewModel.Test/ViewModelTests/MainViewModelTests.cs
@@ -72,7 +72,7 @@ namespace MediaPlayer.ViewModel.Test.ViewModelTests
                 .Setup(x => x.UpdateMetadataAsync(TestData.MediaItems.OfType<AudioItem>(), It.IsAny<CancellationToken>()))
                 .Callback((IEnumerable<AudioItem> audioItems, CancellationToken token) => {
 
-                    audioItems.ToList().ForEach(x => x.AlbumArt = new byte[5] { 2, 4, 6, 8, 10 });
+                    audioItems.ToList().ForEach(x => x.EnrichAlbumArt(new byte[5] { 2, 4, 6, 8, 10 }));
 
                 });
 
@@ -263,10 +263,16 @@ namespace MediaPlayer.ViewModel.Test.ViewModelTests
                 "Fakedir/Track 3"
             };
 
+            static TestData()
+            {
+                AudioItem1.SetLyrics("These are lyrics");
+                AudioItem2.SetLyrics("These are lyrics, too");
+                AudioItem3.SetLyrics("I am singing, here are some lyrics woo");
+            }
+
             public static AudioItem AudioItem1 = new AudioItem
             {
                 Id = 1,
-                Lyrics = "These are lyrics",
                 Album = "Test Album",
                 MediaTitle = "Track 1"
             };
@@ -274,7 +280,6 @@ namespace MediaPlayer.ViewModel.Test.ViewModelTests
             public static AudioItem AudioItem2 = new AudioItem
             {
                 Id = 2,
-                Lyrics = "These are lyrics, too",
                 Album = "Test Album",
                 MediaTitle = "Track 2"
             };
@@ -282,7 +287,6 @@ namespace MediaPlayer.ViewModel.Test.ViewModelTests
             public static AudioItem AudioItem3 = new AudioItem
             {
                 Id = 3,
-                Lyrics = "I am singing, here are some lyrics woo",
                 Album = "Test Album",
                 MediaTitle = "Track 3"
             };

--- a/src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs
+++ b/src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs
@@ -72,7 +72,7 @@ namespace MediaPlayer.ViewModel.Services.Concrete
 
             var updateItems = audioItems.Where(x => !x.HasLyrics).ToList();
 
-            updateItems.ForEach(x => x.Lyrics = lyricsDictionary.GetValueOrDefault(x.FileName));
+            updateItems.ForEach(x => x.EnrichLyrics(lyricsDictionary.GetValueOrDefault(x.FileName)));
         }
 
         private async Task UpdateAlbumArtAsync(IEnumerable<AudioItem> audioItems, CancellationToken token)
@@ -111,7 +111,7 @@ namespace MediaPlayer.ViewModel.Services.Concrete
 
             var updateItems = audioItems.Where(x => !x.HasAlbumArt).ToList();
 
-            updateItems.ForEach(x => x.AlbumArt = albumArtDictionary.GetValueOrDefault(x.FileName));
+            updateItems.ForEach(x => x.EnrichAlbumArt(albumArtDictionary.GetValueOrDefault(x.FileName)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- `AudioItem.AlbumArt` / `AudioItem.Lyrics` are now read-only properties; mutation goes through intent-named methods on the entity.
- `EnrichAlbumArt` / `EnrichLyrics` apply newly-discovered metadata and mark `DirtyProperties`; `DisplayLocalAlbumArt` / `SetLyrics` set the value without marking it dirty (for loading from file and for the correctors).
- Removes the "set the property, then `DirtyProperties.Remove(...)` from outside" workaround in `AudioItemBuilder`, `AlbumArtCorrector`, and `LyricsCorrector` — `DirtyProperties` is now only ever appended to, and only by `Enrich*`.
- `MetadataUpdateService` write-back passes use `EnrichAlbumArt` / `EnrichLyrics`.
- Test fixtures updated accordingly (`TestData` classes set lyrics via a static constructor since object initializers can't call the new methods).

## Test plan
- [x] `dotnet build MediaPlayer.sln` — clean (0 warnings, 0 errors)
- [x] `dotnet test MediaPlayer.ViewModel.Test` — 34/34 pass
- [ ] Smoke-test: load a folder of MP3s (some with embedded art, some without), confirm album art / lyrics still populate from Last.fm / LyricsOVH and folder cover art, and that on exit only genuinely-changed items get written back

🤖 Generated with [Claude Code](https://claude.com/claude-code)