### PR TITLE
Speed up metadata updates and refresh the auto-accent sooner

### DIFF
--- a/docs/AUTO_ACCENT_FOLLOWS_ALBUM_ART_PLAN.md
+++ b/docs/AUTO_ACCENT_FOLLOWS_ALBUM_ART_PLAN.md
@@ -1,0 +1,60 @@
+# Auto-Accent Follows Album-Art Changes Plan
+
+## Context
+
+When loading files with metadata-update enabled, `MetadataUpdateService.UpdateMetadataAsync` runs the
+album-art fetch (LastFM) and the lyrics fetch (LyricsOVH) in parallel and waits for **both**
+(`Task.WhenAll`) before returning. Only after that does `MainViewModel.ProcessFilePathsAsync` send
+`MessengerMessages.AutoAdjustAccent`. The album-art task usually finishes first (LyricsOVH frequently
+404s / is slow), so the user sees the new cover art on the playing track while the UI accent stays stale
+until "Updating Metadata" fully completes.
+
+**Outcome:** raise the accent-recalculation signal as soon as the album-art batch is applied, instead of
+waiting for the lyrics phase too.
+
+## Approach
+
+`MetadataUpdateService.UpdateAlbumArtAsync` already has a natural "album art is done" boundary — the
+`updateItems.ForEach(x => x.EnrichAlbumArt(...))` line. Send `MessengerMessages.AutoAdjustAccent` right
+after it. `MetadataUpdateService` lives in the `MediaPlayer.ViewModel` project, which already references
+`Generic.Mediator` and `MediaPlayer.Common.Enumerations`, so this is in-keeping with the layer. The
+existing `AutoAdjustAccent` handler in `MessengerRegistrations` reads
+`MainViewModel.SelectedMediaItem.AlbumArt` fresh, so no other change is needed.
+
+Rejected alternatives:
+- Sending from `AudioItem.DisplayLocalAlbumArt` (the model) — wrong layer (UI side effect in a domain
+  entity) and wrong granularity: it runs per-item for every track (builder, batch enrich, corrector), so
+  a bulk load would fire N+ messages and re-run dominant-colour extraction N times on the same selected
+  track.
+- Observing `PropertyChanged` on the selected item from `MainViewModel` — requires manual
+  subscribe/unsubscribe lifecycle in the setter.
+
+### Changes — `src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs`
+
+- Add `using Generic.Mediator;` and `using MediaPlayer.Common.Enumerations;`.
+- In `UpdateAlbumArtAsync`, after `updateItems.ForEach(x => x.EnrichAlbumArt(...));`, add:
+  `Messenger<MessengerMessages>.Send(MessengerMessages.AutoAdjustAccent);`
+
+No changes to `AudioItem`, `MainViewModel`, `ThemeViewModel`, or `MessengerRegistrations`. The existing
+`Messenger.Send(AutoAdjustAccent)` at `MainViewModel.cs:149` (after `UpdateMetadataAsync` →
+`FixMetadata`) stays as the backstop: it covers the cover.jpg/folder.jpg corrector path and the
+"metadata update disabled" path. Net effect: in the common case the accent updates once when album art
+lands (mid-"Updating Metadata"), then once more at the end if the corrector changed anything — a
+double-update only in the narrow "LastFM gave nothing but a local cover.jpg exists" case.
+
+## Verification
+
+1. `dotnet build src/MediaPlayer.sln`.
+2. `dotnet test src/MediaPlayer.ViewModel.Test`.
+3. `dotnet run --project src/MediaPlayer.Shell`.
+4. Ensure "Update metadata" and "Auto adjust accent" are enabled in settings. Open a folder of MP3s that
+   lack embedded cover art (so LastFM supplies art) and where some tracks also lack lyrics (so the lyrics
+   phase runs long).
+5. Confirm: while "Updating Metadata..." is still showing, when the playing track's cover art appears the
+   window accent color changes at (essentially) the same moment — not after the status returns to
+   "Media List".
+6. Regression checks:
+   - Selecting a different track still re-runs auto-accent (uses the new art, or resets if none).
+   - Tracks that already have embedded art still get the correct accent on selection.
+   - Clearing the media list / closing mid-update doesn't throw.
+   - With "Auto adjust accent" off, no accent change occurs.

--- a/docs/LYRICS_RETRIEVAL_SPEEDUP_PLAN.md
+++ b/docs/LYRICS_RETRIEVAL_SPEEDUP_PLAN.md
@@ -1,0 +1,56 @@
+# Lyrics Retrieval Speedup Plan — bound the latency
+
+## Context
+
+Loading audio files with metadata-update enabled feels slow, and the lyrics phase (LyricsOVH) is the laggy
+part. Causes:
+
+1. **`api.lyrics.ovh` is slow/flaky and 404s a lot** — unavoidable floor; not addressed here.
+2. **No per-request timeout** — `LyricsOvhApi.GetLyricsAsync` called `GetJsonAsync<>()` with no timeout, so
+   it inherited Flurl's **100-second** default. A single stuck request ties up a worker for that long.
+3. **Concurrency capped at CPU core count** — `MetadataUpdateService.UpdateLyricsAsync` (and
+   `UpdateAlbumArtAsync`) used `Parallel.ForEachAsync` with no `MaxDegreeOfParallelism`, so it defaulted to
+   `Environment.ProcessorCount` (~4–8). For network-bound work that's far too low; combined with #2 a few
+   slow tracks at the front stall everything behind them.
+
+Caching is deliberately *not* part of this: lyrics are keyed by artist+title (unique per track), so unlike
+the album-art path (many tracks share one image URL) there's nothing to dedupe within a load.
+
+**Outcome:** a hung lyrics request fails fast (~5s) instead of after 100s, and many more tracks are fetched
+concurrently — so the lyrics phase no longer stalls on a handful of slow requests.
+
+## Changes
+
+### 1. `src/Integration.LyricsOVH/Services/Concrete/LyricsOvhApi.cs` — per-request timeout
+
+Added `const int TimeoutSeconds = 5;` and `.WithTimeout(TimeoutSeconds)` before `.GetJsonAsync<>()`. The
+existing `catch (Exception)` already catches `FlurlHttpTimeoutException` and returns `null`, so a timeout
+is treated exactly like "no lyrics found" (same as a 404) — no behavior change beyond the bound. 5s is
+generous for a working response and tunable via the const.
+
+### 2. `src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs` — raise parallelism
+
+Added `const int MaxConcurrentRequests = 8;`. In **both** `UpdateLyricsAsync` and `UpdateAlbumArtAsync`,
+the `Parallel.ForEachAsync` calls now pass a
+`ParallelOptions { MaxDegreeOfParallelism = MaxConcurrentRequests, CancellationToken = token }` instead of
+the bare token. 8 is a deliberate middle ground — well above low-end core counts, not so high it risks 429s
+from a fragile free API; tunable via the const.
+
+While here, the "which items still need fetching" filtering moved up into `UpdateMetadataAsync`
+(`audioItems.Where(x => !x.HasAlbumArt)` / `!x.HasLyrics`), so the two private methods no longer carry
+duplicate `if (audioItem.HasX) return;` guards; each materializes its incoming sequence once
+(`var updateItems = audioItems.ToList();`) and uses that list for both the parallel loop and the enrich
+pass. `Task.Run(..., token)` and the cancellation catches are unchanged.
+
+Out of scope: LastFM's `GetTrackInfoAsync` also has no timeout — a candidate for the same treatment later.
+
+## Verification
+
+1. `dotnet build src/MediaPlayer.sln`.
+2. `dotnet test src/MediaPlayer.ViewModel.Test`.
+3. `dotnet run --project src/MediaPlayer.Shell` with "Update metadata" enabled; open a folder of ~20+ MP3s
+   without embedded lyrics (a mix of mainstream tracks that have lyrics and obscure/instrumental ones that
+   404). Confirm the "Updating Metadata..." phase finishes noticeably faster and never hangs for ~100s on
+   one bad track.
+4. Confirm lyrics still populate for tracks that have them (open the lyrics pane on a known track).
+5. Clear the media list mid-update — confirm it still cancels cleanly without throwing.

--- a/src/Integration.LyricsOVH/Services/Concrete/LyricsOvhApi.cs
+++ b/src/Integration.LyricsOVH/Services/Concrete/LyricsOvhApi.cs
@@ -11,6 +11,8 @@ namespace Integration.LyricsOVH.Services.Concrete
     [Export(typeof(ILyricsOvhApi))]
     public class LyricsOvhApi : ILyricsOvhApi
     {
+        const int TimeoutSeconds = 5;
+
         public async Task<LyricsOvhResponse?> GetLyricsAsync(string artist, string track)
         {
             try
@@ -18,6 +20,7 @@ namespace Integration.LyricsOVH.Services.Concrete
                 return await "https://api.lyrics.ovh"
                     .AppendPathSegments("v1")
                     .AppendPathSegments(artist, track)
+                    .WithTimeout(TimeoutSeconds)
                     .GetJsonAsync<LyricsOvhResponse>();
             }
             catch (Exception)

--- a/src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs
+++ b/src/MediaPlayer.ViewModel/Services/Concrete/MetadataUpdateService.cs
@@ -7,8 +7,10 @@ using System.Linq;
 using System.Threading;
 using System.Collections.Concurrent;
 using MediaPlayer.Common.Constants;
+using MediaPlayer.Common.Enumerations;
 using MediaPlayer.Model.Metadata.Abstract.Updaters;
 using Generic.Extensions;
+using Generic.Mediator;
 using System;
 
 namespace MediaPlayer.ViewModel.Services.Concrete
@@ -16,6 +18,8 @@ namespace MediaPlayer.ViewModel.Services.Concrete
     [Export(typeof(IMetadataUpdateService))]
     public class MetadataUpdateService : IMetadataUpdateService
     {
+        const int MaxConcurrentRequests = 8;
+
         readonly IAlbumArtMetadataUpdater _albumArtMetadataUpdater;
         readonly ILyricsMetadataUpdater _lyricsMetadataUpdater;
 
@@ -29,27 +33,31 @@ namespace MediaPlayer.ViewModel.Services.Concrete
 
         public async Task UpdateMetadataAsync(IEnumerable<AudioItem> audioItems, CancellationToken token)
         {
-            var updateAlbumArtTask = UpdateAlbumArtAsync(audioItems, token);
-            var updateLyricsTask = UpdateLyricsAsync(audioItems, token);
+            var updateAlbumArtTask = UpdateAlbumArtAsync(audioItems.Where(x => !x.HasAlbumArt), token);
+            var updateLyricsTask = UpdateLyricsAsync(audioItems.Where(x => !x.HasLyrics), token);
 
             await Task.WhenAll(updateAlbumArtTask, updateLyricsTask);
         }
 
         private async Task UpdateLyricsAsync(IEnumerable<AudioItem> audioItems, CancellationToken token)
         {
+            var updateItems = audioItems.ToList();
             var lyricsDictionary = new ConcurrentDictionary<string, string>();
 
-            await Task.Run(async () => 
+            await Task.Run(async () =>
             {
 
                 try
                 {
-                    await Parallel.ForEachAsync(audioItems, token, async (audioItem, token) =>
+                    var parallelOptions = new ParallelOptions 
+                    { 
+                        MaxDegreeOfParallelism = MaxConcurrentRequests, 
+                        CancellationToken = token 
+                    };
+
+                    await Parallel.ForEachAsync(updateItems, parallelOptions, async (audioItem, token) =>
                     {
                         token.ThrowIfCancellationRequested();
-
-                        if (audioItem.HasLyrics)
-                            return;
 
                         var lyrics = await _lyricsMetadataUpdater.GetLyricsAsync(audioItem.Artist, audioItem.MediaTitle);
 
@@ -70,25 +78,27 @@ namespace MediaPlayer.ViewModel.Services.Concrete
 
             }, token);
 
-            var updateItems = audioItems.Where(x => !x.HasLyrics).ToList();
-
             updateItems.ForEach(x => x.EnrichLyrics(lyricsDictionary.GetValueOrDefault(x.FileName)));
         }
 
         private async Task UpdateAlbumArtAsync(IEnumerable<AudioItem> audioItems, CancellationToken token)
         {
+            var updateItems = audioItems.ToList();
             var albumArtDictionary = new ConcurrentDictionary<string, byte[]>();
 
-            await Task.Run(async () => 
+            await Task.Run(async () =>
             {
                 try
                 {
-                    await Parallel.ForEachAsync(audioItems, token, async (audioItem, token) =>
+                    var parallelOptions = new ParallelOptions 
+                    { 
+                        MaxDegreeOfParallelism = MaxConcurrentRequests, 
+                        CancellationToken = token 
+                    };
+
+                    await Parallel.ForEachAsync(updateItems, parallelOptions, async (audioItem, token) =>
                     {
                         token.ThrowIfCancellationRequested();
-
-                        if (audioItem.HasAlbumArt)
-                            return;
 
                         var albumArt = await _albumArtMetadataUpdater.GetAlbumArtAsync(audioItem.Artist, audioItem.MediaTitle);
 
@@ -109,9 +119,9 @@ namespace MediaPlayer.ViewModel.Services.Concrete
 
             }, token);
 
-            var updateItems = audioItems.Where(x => !x.HasAlbumArt).ToList();
-
             updateItems.ForEach(x => x.EnrichAlbumArt(albumArtDictionary.GetValueOrDefault(x.FileName)));
+
+            Messenger<MessengerMessages>.Send(MessengerMessages.AutoAdjustAccent);
         }
     }
 }


### PR DESCRIPTION
## Summary

Two related improvements to the post-load metadata pipeline:

- **Auto-accent updates sooner.** It used to recolour the window only after `MetadataUpdateService.UpdateMetadataAsync` finished — which waits on `Task.WhenAll(albumArt, lyrics)`, and the LyricsOVH phase is the slow one. Now `AutoAdjustAccent` is sent at the end of `UpdateAlbumArtAsync`, so the accent follows the new cover art the moment it lands (still mid-"Updating Metadata..."). The existing send at the end of `ProcessFilePathsAsync` stays as the backstop for the cover.jpg corrector / "update metadata disabled" paths.
- **Lyrics fetch stops stalling the batch.** `LyricsOvhApi` now uses a 5s per-request timeout (was Flurl's 100s default), and both metadata fetch loops run with `MaxDegreeOfParallelism = 8` instead of the `ProcessorCount` default. While in there, the "still needs fetching" filtering moved up into `UpdateMetadataAsync` (dropping the duplicate `if (audioItem.HasX) return;` guards) and each method materializes its incoming sequence once.

Design notes for both changes are in `docs/AUTO_ACCENT_FOLLOWS_ALBUM_ART_PLAN.md` and `docs/LYRICS_RETRIEVAL_SPEEDUP_PLAN.md`. (Caching the lyrics path was considered and rejected — lyrics are keyed by artist+title, unique per track, so unlike album art there's nothing to dedupe within a load.)

## Test plan

- [x] `dotnet build src/MediaPlayer.sln` — clean
- [x] `dotnet test src/MediaPlayer.ViewModel.Test` — 34/34 pass
- [ ] Manual: load a folder of MP3s lacking embedded art + lyrics with "Update metadata" and "Auto adjust accent" on; confirm the accent flips when the playing track's art appears (not at the end), the "Updating Metadata..." phase finishes faster, and no ~100s hang on a bad track
- [ ] Manual: clear the media list mid-update — cancels cleanly, no exception
- [ ] Manual: lyrics still populate for tracks that have them

🤖 Generated with [Claude Code](https://claude.com/claude-code)